### PR TITLE
Bump Ironbank build context to ubi 8.5

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/Dockerfile
@@ -4,7 +4,7 @@
 ################################################################################
 ARG BASE_REGISTRY=registry1.dsop.io
 ARG BASE_IMAGE=redhat/ubi/ubi8
-ARG BASE_TAG=8.4
+ARG BASE_TAG=8.5
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as prep_files
 

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/hardening_manifest.yaml
@@ -14,7 +14,7 @@ tags:
 # Build args passed to Dockerfile ARGs
 args:
   BASE_IMAGE: 'redhat/ubi/ubi8'
-  BASE_TAG: '8.4'
+  BASE_TAG: '8.5'
 
 # Docker image labels
 labels:


### PR DESCRIPTION
This commit updates the Ironbank build context to use ubi:8.5 as base
image.
